### PR TITLE
feat (cmd_sign): sign partially parsed envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,47 @@
 Implementation of SUIT envelope generator based on input yaml or json string.
 
 ## Installation
-```
+```shell
 git clone https://github.com/NordicSemiconductor/suit-generator.git
 cd suit-generator
 pip install .
 ```
 
 ## Testing
-```
+```shell
 cd suit-generator/tests
 pytest
 ```
 
 ## Basic usage
-```
+```shell
 suit-genrator --help
 ```
 
-## Package build and release
+### Envelope creation
+```shell
+cd examples/input_files
+dd if=/dev/zero of=file.bin bs=1024 count=1
+suit-generator create --input-file example/input_files/envelope_1.json --output-file envelope.suit
 ```
+
+### Key generation
+```shell
+suit-generator keys --output-file key
+```
+
+### Key conversion
+```shell
+suit-generator convert --input-file key_private.pem --output-file key_public.c
+```
+
+### Adding signature
+```shell
+suit-genrator sign --input-file envelope.suit --output-file envelope_signed.suit --private-key key_private.pem
+```
+
+## Package build and release
+```shell
 python setup.py --version
 git tag vX.Y.Z
 python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dynamic = ["version","dependencies"]
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+[tool.setuptools]
+py-modules = []
+
 [project.scripts]
 suit-generator = "suit_generator.cli:main"
 

--- a/suit_generator/cmd_sign.py
+++ b/suit_generator/cmd_sign.py
@@ -29,8 +29,8 @@ class LocalSigner(Signer):
         log.info(f"signing {input_file=} by {key=} and storing as {output_file=}")
         try:
             envelope = SuitEnvelope()
-            envelope.load(input_file, "suit")
-            envelope.dump(output_file, "suit", private_key=key)
+            envelope.load(input_file, "suit_simplified")
+            envelope.dump(output_file, "suit_simplified", private_key=key)
         except ValueError as error:
             raise SUITError(f"Invalid value: {error}") from error
         except FileNotFoundError as error:

--- a/suit_generator/suit/types/common.py
+++ b/suit_generator/suit/types/common.py
@@ -128,6 +128,15 @@ class SuitObject:
         else:
             raise ValueError("Not possible to get value!")
 
+    @value.setter
+    def value(self, value):
+        """Link to dynamically created SUIT attribute."""
+        for item in self.__dict__:
+            if "Suit" in item or "Cose" in item:
+                return setattr(self, item, value)
+        else:
+            raise ValueError("Not possible to get value!")
+
     @classmethod
     def from_obj(cls, obj):
         """Restore SUIT representation from passed object."""

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-mock
 deepdiff
+intelhex


### PR DESCRIPTION
SuitEnvelopeTaggedSimplified added to simplify signing process (parsing of input envelope is done only on the first level for elements other than authentication wrapper)

Ref: NCSDK-20915

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>