### PR TITLE
feat (licenses): add missing licenses in the sh scripts.

### DIFF
--- a/doc/build_doc.sh
+++ b/doc/build_doc.sh
@@ -1,0 +1,5 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#

--- a/examples/input_files/create_envelopes.sh
+++ b/examples/input_files/create_envelopes.sh
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
 #!/usr/bin/env sh
 # Create two basic envelopes containing dummy payloads.
 dd if=/dev/zero of=file.bin bs=1024 count=1


### PR DESCRIPTION
Feat: add missing licenses in the sh scripts.

Ref: NCSDK-21712

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>