### PR TITLE
suit: Align UUIDs with values returned by MCI

### DIFF
--- a/ncs/default_app_rad_cores_envelope.yaml.jinja2
+++ b/ncs/default_app_rad_cores_envelope.yaml.jinja2
@@ -35,7 +35,7 @@ SUIT_Envelope_Tagged:
           suit-parameter-class-identifier:
             RFC4122_UUID:
               namespace: nordicsemi.com
-              name: nRF5420_cpuapp
+              name: nRF54H20_sample_app
       - suit-condition-vendor-identifier:
         - suit-send-record-success
         - suit-send-record-failure
@@ -142,6 +142,13 @@ SUIT_Envelope_Tagged:
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
+{%- endif %}
+    suit-manifest-component-id:
+{%- if app is defined %}
+    - I
+    - RFC4122_UUID:
+        namespace: nordicsemi.com
+        name: nRF54H20_sample_app
 {%- endif %}
   suit-integrated-payloads:
 {%- if app is defined %}

--- a/ncs/default_appcore_envelope.yaml.jinja2
+++ b/ncs/default_appcore_envelope.yaml.jinja2
@@ -17,9 +17,12 @@ SUIT_Envelope_Tagged:
       - suit-directive-set-component-index: 0
       - suit-directive-override-parameters:
           suit-parameter-vendor-identifier:
-            raw: 7617daa571fd5a858f94e28d735ce9f4
+            RFC4122_UUID:
+              name: nordicsemi.com
           suit-parameter-class-identifier:
-            raw: d622bafd4337518590bc6368cda7fbca
+            RFC4122_UUID:
+              namespace: nordicsemi.com
+              name: nRF54H20_sample_app
       - suit-condition-vendor-identifier:
         - suit-send-record-success
         - suit-send-record-failure
@@ -70,5 +73,10 @@ SUIT_Envelope_Tagged:
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
+    suit-manifest-component-id:
+    - I
+    - RFC4122_UUID:
+        namespace: nordicsemi.com
+        name: nRF54H20_sample_app
   suit-integrated-payloads:
     '#{{ app['name'] }}': {{ app['binary'] }}


### PR DESCRIPTION
Use "nRF54H20_sample_app" for default nRF54 applications, as defined in SUIT MCI module.
Add manifest component ID, so the manifest can be handled by the new SUIT storage module.