### PR TITLE
fix: NCSDK-23838 (Doc building issue) and missing convert cmd

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -20,3 +20,4 @@ sphinxcontrib-websupport==1.2.2
 sphinx-markdown-builder==0.5.5
 sphinx-argparse==0.4.0
 build==0.10.0
+virtualenv

--- a/suit_generator/args.py
+++ b/suit_generator/args.py
@@ -14,6 +14,7 @@ from suit_generator.cmd_parse import add_arguments as parse_args
 from suit_generator.cmd_keys import add_arguments as key_args
 from suit_generator.cmd_sign import add_arguments as sign_args
 from suit_generator.cmd_image import add_arguments as image_args
+from suit_generator.cmd_convert import add_arguments as convert_args
 
 
 def _parser() -> ArgumentParser:
@@ -24,6 +25,7 @@ def _parser() -> ArgumentParser:
     key_args(subparsers)
     sign_args(subparsers)
     image_args(subparsers)
+    convert_args(subparsers)
     return parser
 
 


### PR DESCRIPTION
fix: NCSDK-23838 (Doc building issue) and missing convert cmd

* fix (doc): added virtualenv needed for building docs
* fix (cmd convert): add missing parser

Signed-off-by: Krzysztof Szromek <krzysztof.szromek@nordicsemi.no>