### PR TITLE
fix (hierarchical manifests): improve digest calculation

### DIFF
--- a/suit_generator/suit/envelope.py
+++ b/suit_generator/suit/envelope.py
@@ -80,7 +80,7 @@ class SuitBasicEnvelopeOperationsMixin:
             1
         ].SuitDigestBytes = new_digest
 
-    def _get_digest(self):
+    def get_digest(self):
         """Return digest from parsed envelope."""
         return self.value.value.value[suit_authentication_wrapper].SuitAuthentication[0].SuitDigest
 


### PR DESCRIPTION
fix (hierarchical manifests): improve calculation of dependent manifest digests

Ref: NCSDK-24125

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>