### PR TITLE
fix: error handling for memory error during cbor decode in union

### DIFF
--- a/suit_generator/suit/types/common.py
+++ b/suit_generator/suit/types/common.py
@@ -236,7 +236,8 @@ class SuitUnion(SuitObject):
             try:
                 value = child.from_cbor(cbstr)
                 break
-            except ValueError:
+            except (ValueError, MemoryError, cbor2.CBORError):
+                # fixme: need to be improved (detect possible MemoryError prior to occurring) - NCSDK-24195
                 pass
         else:
             raise ValueError("Not possible to deserialize data")


### PR DESCRIPTION
fix (cbor parsing): error handling for errors during cbor decode in union

Ref: NCSDK-24195

Signed-off-by: Krzysztof Szromek <krzysztof.szromek@nordicsemi.no>