### PR TITLE
ncs: Support SDFW update files generation

### DIFF
--- a/ncs/Kconfig
+++ b/ncs/Kconfig
@@ -87,6 +87,7 @@ config SUIT_ENVELOPE_EDITABLE_TEMPLATES_LOCATION
       You can use either absolute or relative path.
       In case relative path is used, the build system uses PROJECT_BINARY_DIR directory.
 
+# TODO: Consider renaming to not cause a confusion with SUIT_PREPARE_SECDOM_UPDATE
 config SUIT_ENVELOPE_SECDOM
     bool "Create SUIT files required by secure domain"
     help
@@ -97,12 +98,48 @@ config SUIT_ENVELOPE_SIGN_SCRIPT
     string "Location of SUIT sign script"
     depends on SUIT_ENVELOPE_SIGN
     help
-        Python script called to sing SUIT envelope.
+        Python script called to sign SUIT envelope.
         You can use either absolute or relative path.
         In case relative path is used, the build system uses NRF parent directory.
         Script need to accept two arguments:
         - --input-file <STRING> - location of unsigned envelope in the build system
         - --output-file <STRING> - location of signed envelope to create by script
     default "modules/lib/suit-generator/ncs/sign_script.py"
+
+config SUIT_PREPARE_SECDOM_UPDATE
+  bool "Create SUIT envelope for SDFW update"
+  depends on IS_SECURE_DOMAIN_FW
+  default n
+
+config SUIT_ENVELOPE_CREATE_SECDOM_UPDATE_YAML_SCRIPT
+  string "Location of script for preparing secdom yaml envelope"
+  depends on SUIT_PREPARE_SECDOM_UPDATE
+  help
+      Python script called to generate yaml file for secure domain update.
+      Script requires parameters:
+      - --secdom-update-payload-uri - URI to be used in the yaml
+      - --secdom-update-payload-file - path to secure domain update payload
+      - --template-file - jinja2 template file for creating the yaml file
+      - --envelope-yaml-file - the yaml file to be generated
+  default "${ZEPHYR_SUIT_GENERATOR_MODULE_DIR}/ncs/create_secdom_update_envelope_yaml.py"
+
+config SUIT_ENVELOPE_SECDOM_YAML_TEMPLATE_FILE
+  string "Location of template file for preparing secdom yaml envelope"
+  depends on SUIT_PREPARE_SECDOM_UPDATE
+  help
+      Jinja2 template file used to generate yaml file for secure domain update.
+  default "${ZEPHYR_SUIT_GENERATOR_MODULE_DIR}/ncs/secdom_update_envelope.yaml.jinja2"
+
+config SUIT_ENVELOPE_SECDOM_IMPRIMATUR_SICR_BIN
+  string "Name of Imprimatur's build artifact containing SICR section needed for SDFW update"
+  default "sicr.bin"
+
+config SUIT_ENVELOPE_SECDOM_IMPRIMATUR_PUBLIC_KEY_BIN
+  string "Name of Imprimatur's build artifact containing public key used for signing the SDFW update candidate"
+  default "public_key.bin"
+
+config SUIT_ENVELOPE_SECDOM_IMPRIMATUR_SIGNATURE_BIN
+  string "Name of Imprimatur's build artifact containing signature of the SDFW update candidate"
+  default "signature.bin"
 
 endif # SUIT_ENVELOPE

--- a/ncs/secdom_update_envelope.yaml.jinja2
+++ b/ncs/secdom_update_envelope.yaml.jinja2
@@ -1,0 +1,54 @@
+SUIT_Envelope_Tagged:
+  suit-authentication-wrapper:
+    SuitDigest:
+      suit-digest-algorithm-id: cose-alg-sha-256
+  suit-manifest:
+    suit-manifest-version: 1
+    suit-manifest-sequence-number: 1
+    suit-common:
+      suit-components:
+      - - SOC_SPEC
+        - 1
+      - - CAND_IMG
+        - 0
+      suit-shared-sequence:
+      - suit-directive-set-component-index: 0
+      - suit-directive-override-parameters:
+          suit-parameter-vendor-identifier:
+            RFC4122_UUID:
+              name: nordicsemi.com
+          suit-parameter-class-identifier:
+            RFC4122_UUID:
+              namespace: nordicsemi.com
+              name: nRF54H20_sec_sys
+      - suit-condition-vendor-identifier:
+        - suit-send-record-success
+        - suit-send-record-failure
+        - suit-send-sysinfo-success
+        - suit-send-sysinfo-failure
+      - suit-condition-class-identifier:
+        - suit-send-record-success
+        - suit-send-record-failure
+        - suit-send-sysinfo-success
+        - suit-send-sysinfo-failure
+      - suit-directive-override-parameters:
+          suit-parameter-image-size:
+            file: '{{ secdom['binary'] }}'
+    suit-install:
+    - suit-directive-set-component-index: 1
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ secdom['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-directive-set-component-index: 0
+    - suit-directive-override-parameters:
+        suit-parameter-source-component: 1
+    - suit-directive-copy:
+      - suit-send-record-failure
+    suit-manifest-component-id:
+    - INSTLD_MFST
+    - RFC4122_UUID:
+        namespace: nordicsemi.com
+        name: nRF54H20_sec_sys
+  suit-integrated-payloads:
+    '#{{ secdom['name'] }}': {{ secdom['binary'] }}


### PR DESCRIPTION
Initial proposal of changes in order to build secure domain SUIT files needed for updating FPGA.
At the moment it will be used by SDFW build process (not a part of smp_transfer sample as it is not yet aligned with fp1).