### PR TITLE
templates: Verify firmware before install

### DIFF
--- a/ncs/app_envelope.yaml.jinja2
+++ b/ncs/app_envelope.yaml.jinja2
@@ -11,7 +11,10 @@ SUIT_Envelope_Tagged:
         - {{ app['dt'].label2node['cpu'].unit_addr }}
         - {{ get_absolute_address(app['dt'].chosen_nodes['zephyr,code-partition']) }}
         - {{ app['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
+      - - CAND_IMG
+        - 0
       suit-shared-sequence:
+      - suit-directive-set-component-index: 0
       - suit-directive-override-parameters:
           suit-parameter-vendor-identifier:
             RFC4122_UUID: nordicsemi.com
@@ -35,19 +38,40 @@ SUIT_Envelope_Tagged:
         - suit-send-record-failure
         - suit-send-sysinfo-success
         - suit-send-sysinfo-failure
+      - suit-directive-set-component-index: 1
+      - suit-directive-override-parameters:
+          suit-parameter-image-digest:
+            suit-digest-algorithm-id: cose-alg-sha-256
+            suit-digest-bytes:
+              file: {{ app['binary'] }}
+          suit-parameter-image-size:
+            file: {{ app['binary'] }}
     suit-validate:
+    - suit-directive-set-component-index: 0
     - suit-condition-image-match:
       - suit-send-record-success
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
     suit-invoke:
+    - suit-directive-set-component-index: 0
     - suit-directive-invoke:
       - suit-send-record-failure
     suit-install:
+    - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ app['name'] }}'
     - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-image-match:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-set-component-index: 0
+    - suit-directive-override-parameters:
+        suit-parameter-source-component: 1
+    - suit-directive-copy:
       - suit-send-record-failure
     - suit-condition-image-match:
       - suit-send-record-success

--- a/ncs/rad_envelope.yaml.jinja2
+++ b/ncs/rad_envelope.yaml.jinja2
@@ -11,7 +11,10 @@ SUIT_Envelope_Tagged:
         - {{ hci_rpmsg_subimage['dt'].label2node['cpu'].unit_addr }}
         - {{ get_absolute_address(hci_rpmsg_subimage['dt'].chosen_nodes['zephyr,code-partition']) }}
         - {{ hci_rpmsg_subimage['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
+      - - CAND_IMG
+        - 0
       suit-shared-sequence:
+      - suit-directive-set-component-index: 0
       - suit-directive-override-parameters:
           suit-parameter-vendor-identifier:
             RFC4122_UUID: nordicsemi.com
@@ -35,19 +38,40 @@ SUIT_Envelope_Tagged:
         - suit-send-record-failure
         - suit-send-sysinfo-success
         - suit-send-sysinfo-failure
+      - suit-directive-set-component-index: 1
+      - suit-directive-override-parameters:
+          suit-parameter-image-digest:
+            suit-digest-algorithm-id: cose-alg-sha-256
+            suit-digest-bytes:
+              file: {{ hci_rpmsg_subimage['binary'] }}
+          suit-parameter-image-size:
+            file: {{ app['binary'] }}
     suit-validate:
+    - suit-directive-set-component-index: 0
     - suit-condition-image-match:
       - suit-send-record-success
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
     suit-invoke:
+    - suit-directive-set-component-index: 0
     - suit-directive-invoke:
       - suit-send-record-failure
     suit-install:
+    - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ hci_rpmsg_subimage['name'] }}'
     - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-image-match:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-set-component-index: 0
+    - suit-directive-override-parameters:
+        suit-parameter-source-component: 1
+    - suit-directive-copy:
       - suit-send-record-failure
     - suit-condition-image-match:
       - suit-send-record-success


### PR DESCRIPTION
Use CAND_IMG component to verify integrated payloads before copying them into destination area.