### PR TITLE
ncs: Fix secdom update envelope template

### DIFF
--- a/ncs/secdom_update_envelope.yaml.jinja2
+++ b/ncs/secdom_update_envelope.yaml.jinja2
@@ -31,9 +31,6 @@ SUIT_Envelope_Tagged:
         - suit-send-record-failure
         - suit-send-sysinfo-success
         - suit-send-sysinfo-failure
-      - suit-directive-override-parameters:
-          suit-parameter-image-size:
-            file: '{{ secdom['binary'] }}'
     suit-install:
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:


### PR DESCRIPTION
suit_plat_override_image_size is now allowed only for MEM components. Remove the directive from secdom update envelope template.

Ref: NCSDK-24753