### PR TITLE
NCSDK-24831: common: Fix parsing simplified envelopes with deps

### DIFF
--- a/suit_generator/suit/envelope.py
+++ b/suit_generator/suit/envelope.py
@@ -40,6 +40,7 @@ class SuitEnvelopeSimplified(SuitKeyValue):
             suit_install: SuitBstr,
             suit_text: SuitBstr,
             suit_integrated_payloads: SuitIntegratedPayloadMap,
+            suit_integrated_dependencies: SuitIntegratedPayloadMap,
         },
         embedded=[suit_integrated_payloads],
     )

--- a/suit_generator/suit/types/common.py
+++ b/suit_generator/suit/types/common.py
@@ -440,6 +440,10 @@ class SuitKeyValue(SuitObject):
                             item = suit_integrated_dependencies
                         except Exception:
                             pass
+
+                        if item not in cls._metadata.map:
+                            raise ValueError(f"Impossible to create embedded element: {item}")
+
                         # TODO: refactoring required: workaround for multiple integrated payloads
                         if item in value and (item is suit_integrated_payloads or item is suit_integrated_dependencies):
                             value[item].SuitIntegratedPayloadMap = {


### PR DESCRIPTION
The SimplifiedEnvelope may contain integrated dependencies, as it is "simplified" through not parsing internal elements, not by severing them.