### PR TITLE
cmd_image: storages for different domains generated to separate files

### DIFF
--- a/ncs/build.py
+++ b/ncs/build.py
@@ -77,7 +77,7 @@ cmd_template_arg_parser = subparsers.add_parser(
     TEMPLATE_CMD, help="Generate SUIT configuration files based on input templates.", parents=[parent_parser]
 )
 cmd_storage_arg_parser = subparsers.add_parser(
-    STORAGE_CMD, help="Generate SUIT storage required by scecure domain.", parents=[parent_parser]
+    STORAGE_CMD, help="Generate SUIT storage required by secure domain.", parents=[parent_parser]
 )
 
 cmd_template_arg_parser.add_argument("--version", required=True, default=1, help="Update version.")
@@ -87,7 +87,9 @@ cmd_template_arg_parser.add_argument("--output-suit", required=True, help="Outpu
 cmd_storage_arg_parser.add_argument(
     "--input-envelope", required=True, action="append", help="Location of input envelope(s)."
 )
-cmd_storage_arg_parser.add_argument("--storage-output-file", required=True, help="Input binary SUIT envelope.")
+cmd_storage_arg_parser.add_argument(
+    "--storage-output-directory", required=True, help="Directory path to store hex files with SUIT storage contents"
+)
 
 cmd_update_arg_parser = subparsers.add_parser(
     UPDATE_CMD, help="Generate files needed for Secure Domain update", parents=[parent_parser]
@@ -121,7 +123,7 @@ elif arguments.command == STORAGE_CMD:
     # fixme: envelope_address, update_candidate_info_address and dfu_max_caches shall be extracted from DTS
     ImageCreator.create_files_for_boot(
         input_files=arguments.input_envelope,
-        storage_output_file=arguments.storage_output_file,
+        storage_output_directory=arguments.storage_output_directory,
         envelope_address=ImageCreator.default_envelope_address,
         envelope_slot_size=ImageCreator.default_envelope_slot_size,
         envelope_slot_count=ImageCreator.default_envelope_slot_count,

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -39,7 +39,7 @@ def test_create_cmd_mode_auto(mock_args):
             "--array-name",
             "key_buf",
         ],
-        ["image", "boot", "--input-file", "envelope.suit", "--storage-output-file", "storage.hex"],
+        ["image", "boot", "--input-file", "envelope.suit", "--storage-output-directory", "."],
         [
             "image",
             "update",

--- a/tests/test_cmd_image.py
+++ b/tests/test_cmd_image.py
@@ -960,7 +960,7 @@ def test_boot_subcommand_nonexisting_input_file():
         cmd_image_main(
             image="boot",
             input_file=["nonexisting"],
-            storage_output_file="",
+            storage_output_directory="",
             update_candidate_info_address=0,
             envelope_address=0,
             envelope_slot_size=2048,
@@ -979,7 +979,7 @@ def test_boot_subcommand_manifest_without_component_id(mocker):
         cmd_image_main(
             image="boot",
             input_file=["some_input"],
-            storage_output_file="some_output.hex",
+            storage_output_directory="some_output",
             update_candidate_info_address=0x0E1EEC00,
             envelope_address=0x0E1EED80,
             envelope_slot_size=2048,
@@ -997,7 +997,7 @@ def test_boot_subcommand_success(mocker):
     cmd_image_main(
         image="boot",
         input_file=["some_input"],
-        storage_output_file="some_output.hex",
+        storage_output_directory="some_output",
         update_candidate_info_address=0x0E1EEC00,
         envelope_address=0x0E1EED80,
         envelope_slot_size=2048,
@@ -1059,7 +1059,7 @@ def test_malformed_envelope(mocker):
         cmd_image_main(
             image="boot",
             input_file=["some_input"],
-            storage_output_file="some_output.hex",
+            storage_output_directory="some_output",
             update_candidate_info_address=0x0E1FE000,
             envelope_address=0x0E1FF000,
             envelope_slot_size=2048,


### PR DESCRIPTION
This commit adds generation of storage*.hex files separately for different domains.
Generating of a single legacy "storage.hex" is still done for compatibility.