### PR TITLE
ncs: Enable SysCtrl startup in its template

### DIFF
--- a/ncs/sysctrl_envelope.yaml.jinja2
+++ b/ncs/sysctrl_envelope.yaml.jinja2
@@ -48,17 +48,15 @@ SUIT_Envelope_Tagged:
       - suit-directive-set-component-index: 0
       - suit-directive-override-parameters:
           suit-parameter-source-component: 1
-      # TODO: Uncomment once SysCtrl booting is done using SUIT - NCSDK-25614
-      # - suit-directive-copy: []
-      # - suit-condition-image-match: []
+      - suit-directive-copy: []
+      - suit-condition-image-match: []
     suit-invoke:
       - suit-directive-set-component-index: 0
       - suit-directive-override-parameters:
           suit-parameter-image-size:
             file: {{ sysctrl['binary'] }}
-      # TODO: Uncomment once SysCtrl booting is done using SUIT - NCSDK-25614
-      # - suit-condition-image-match: []
-      # - suit-directive-invoke: []
+      - suit-condition-image-match: []
+      - suit-directive-invoke: []
     suit-payload-fetch:
       - suit-directive-set-component-index: 2
       - suit-directive-override-parameters:


### PR DESCRIPTION
Uncomment sections requiring support in SUIT platform.

Ref: NCSDK-25614