### PR TITLE
Severe dependency-resolution and candidate-verification in storage

### DIFF
--- a/suit_generator/envelope.py
+++ b/suit_generator/envelope.py
@@ -65,6 +65,8 @@ class SuitEnvelope(InputOutputMixin, EnvelopeApiMixin):
         severable = [
             "suit-payload-fetch",
             "suit-install",
+            "suit-dependency-resolution",
+            "suit-candidate-verification",
             "suit-text",
             "suit-integrated-payloads",
             "suit-integrated-dependencies",


### PR DESCRIPTION
Without this an incorrect envelope is stored when adding these commands as severed ones.

Ref: NCSDK-25353