### PR TITLE
Remove legacy storage.hex generation

### DIFF
--- a/suit_generator/cmd_mpi.py
+++ b/suit_generator/cmd_mpi.py
@@ -90,7 +90,7 @@ def add_arguments(parser):
 
 
 class MpiGenerator:
-    """Class geenrating SUIT Manifest Provisioning Information."""
+    """Class generating SUIT Manifest Provisioning Information."""
 
     BYTE_ORDER = "little"
 


### PR DESCRIPTION
Currently multiple storage_<domain>.hex files are
created and flashed, a single storage.hex is deprecated.