### PR TITLE
fix: Class ID checks for INSTLD_MFST components

### DIFF
--- a/examples/input_files/envelope_2_hierarchical.yaml
+++ b/examples/input_files/envelope_2_hierarchical.yaml
@@ -169,23 +169,14 @@ SUIT_Envelope_Tagged:
             namespace: nordicsemi.com
             name: nRF54H20_sample_app
       suit-shared-sequence:
-      - suit-directive-set-component-index: 1
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: nordicsemi.com
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: nordicsemi.com
-              name: nRF54H20_sample_rad
-      - suit-directive-set-component-index: 2
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: nordicsemi.com
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: nordicsemi.com
-              name: nRF54H20_sample_app
       - suit-directive-set-component-index: [1, 2]
+      - suit-directive-override-parameters:
+          suit-parameter-vendor-identifier:
+            RFC4122_UUID: nordicsemi.com
+          suit-parameter-class-identifier:
+            RFC4122_UUID:
+              namespace: nordicsemi.com
+              name: nRF54H20_sample_root
       - suit-condition-vendor-identifier:
         - suit-send-record-success
         - suit-send-record-failure

--- a/ncs/nordic_top_envelope.yaml.jinja2
+++ b/ncs/nordic_top_envelope.yaml.jinja2
@@ -19,20 +19,12 @@ SUIT_Envelope_Tagged:
             namespace: nordicsemi.com
             name: nRF54H20_sys
       suit-shared-sequence:
-      - suit-directive-set-component-index: 1
-      - suit-directive-override-parameters:
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: nordicsemi.com
-              name: nRF54H20_sec
-      - suit-directive-set-component-index: 2
-      - suit-directive-override-parameters:
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: nordicsemi.com
-              name: nRF54H20_sys
       - suit-directive-set-component-index: [1,2]
       - suit-directive-override-parameters:
+          suit-parameter-class-identifier:
+            RFC4122_UUID:
+              namespace: nordicsemi.com
+              name: nRF54H20_nordic_top
           suit-parameter-vendor-identifier:
             RFC4122_UUID: nordicsemi.com
       - suit-condition-vendor-identifier:

--- a/ncs/root_with_binary_nordic_top.yaml.jinja2
+++ b/ncs/root_with_binary_nordic_top.yaml.jinja2
@@ -54,39 +54,14 @@ SUIT_Envelope_Tagged:
 {%- endif %}
 
       suit-shared-sequence:
-{%- if radio is defined %}
-      - suit-directive-set-component-index: {{ rad_component_index }}
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: {{ mpi_radio_vendor_name }}
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: {{ mpi_radio_vendor_name }}
-              name: {{ mpi_radio_class_name }}
-{%- endif %}
-{%- if application is defined %}
-      - suit-directive-set-component-index: {{ app_component_index }}
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: {{ mpi_application_vendor_name }}
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: {{ mpi_application_vendor_name }}
-              name: {{ mpi_application_class_name }}
-{%- endif %}
-
-{%- if nordic_top is defined %}
-      - suit-directive-set-component-index: {{ top_component_index }}
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: nordicsemi.com
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: nordicsemi.com
-              name: nRF54H20_nordic_top
-{%- endif %}
-
       - suit-directive-set-component-index: [{{ component_list|join(',') }}]
+      - suit-directive-override-parameters:
+          suit-parameter-vendor-identifier:
+            RFC4122_UUID: {{ mpi_root_vendor_name }}
+          suit-parameter-class-identifier:
+            RFC4122_UUID:
+              namespace: {{ mpi_root_vendor_name }}
+              name: {{ mpi_root_class_name }}
       - suit-condition-vendor-identifier:
         - suit-send-record-success
         - suit-send-record-failure

--- a/ncs/root_with_nordic_top_envelope.yaml.jinja2
+++ b/ncs/root_with_nordic_top_envelope.yaml.jinja2
@@ -56,39 +56,14 @@ SUIT_Envelope_Tagged:
 {%- endif %}
 
       suit-shared-sequence:
-{%- if radio is defined %}
-      - suit-directive-set-component-index: {{ rad_component_index }}
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: {{ mpi_rad_vendor_name }}
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: {{ mpi_rad_vendor_name }}
-              name: {{ mpi_rad_class_name }}
-{%- endif %}
-{%- if application is defined %}
-      - suit-directive-set-component-index: {{ app_component_index }}
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: {{ mpi_app_vendor_name }}
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: {{ mpi_app_vendor_name }}
-              name: {{ mpi_app_class_name }}
-{%- endif %}
-
-{%- if top is defined %}
-      - suit-directive-set-component-index: {{ top_component_index }}
-      - suit-directive-override-parameters:
-          suit-parameter-vendor-identifier:
-            RFC4122_UUID: nordicsemi.com
-          suit-parameter-class-identifier:
-            RFC4122_UUID:
-              namespace: nordicsemi.com
-              name: nRF54H20_nordic_top
-{%- endif %}
-
       - suit-directive-set-component-index: [{{ component_list|join(',') }}]
+      - suit-directive-override-parameters:
+          suit-parameter-vendor-identifier:
+            RFC4122_UUID: {{ mpi_root_vendor_name }}
+          suit-parameter-class-identifier:
+            RFC4122_UUID:
+              namespace: {{ mpi_root_vendor_name }}
+              name: {{ mpi_root_class_name }}
       - suit-condition-vendor-identifier:
         - suit-send-record-success
         - suit-send-record-failure


### PR DESCRIPTION
The class ID check verifies if manifest with given class ID can operate on the installed manifest component, not the class ID of the component.