### PR TITLE
suit-generator sysbuild adjustments

### DIFF
--- a/ncs/Kconfig
+++ b/ncs/Kconfig
@@ -26,66 +26,6 @@ config SUIT_ENVELOPE_OUTPUT_MPI_MERGE
   bool "Merge MPI files into final SUIT_ENVELOPE_OUTPUT_ARTIFACT"
   default y
 
-menuconfig SUIT_ENVELOPE
-    bool "Create SUIT envelope"
-    help
-        Enable DFU SUIT envelope creation
-    default y if SSF_SUIT_SERVICE_ENABLED && SOC_NRF54H20_CPUAPP
-
-if SUIT_ENVELOPE
-
-config SUIT_ENVELOPE_SIGN
-    bool "Sign created SUIT envelope"
-    help
-        Sign created SUIT envelope by external script
-    default n
-
-config SUIT_ENVELOPE_SEQUENCE_NUM
-    int "Sequence number of the generated SUIT manifest"
-    range 0 2147483647
-    default 1
-
-config SUIT_ENVELOPE_ROOT_TEMPLATE
-    string "Path to the default root envelope template"
-    default "${ZEPHYR_SUIT_GENERATOR_MODULE_DIR}/ncs/root_with_binary_nordic_top.yaml.jinja2" if SOC_NRF54H20_CPUAPP
-    help
-      Path to the default root envelope template, that is used if the application directory does not
-      contain an input envelope template file.
-      You can use either absolute or relative path.
-      In case relative path is used, the build system uses CMAKE_SOURCE_DIR directory.
-
-config SUIT_ENVELOPE_EDITABLE_TEMPLATES_LOCATION
-    string "Path to the folder with envelope templates"
-    default "../"
-    help
-      Path to the folder containing editable templates used to create binary envelopes.
-      Input templates are created by the build system during first build from the SUIT_ENVELOPE_DEFAULT_TEMPLATE.
-      You can use either absolute or relative path.
-      In case relative path is used, the build system uses CMAKE_SOURCE_DIR directory.
-
-config SUIT_ENVELOPE_SIGN_SCRIPT
-    string "Location of SUIT sign script"
-    depends on SUIT_ENVELOPE_SIGN
-    help
-        Python script called to sign SUIT envelope.
-        You can use either absolute or relative path.
-        In case relative path is used, the build system uses NRF parent directory.
-        Script need to accept two arguments:
-        - --input-file <STRING> - location of unsigned envelope in the build system
-        - --output-file <STRING> - location of signed envelope to create by script
-    default "modules/lib/suit-generator/ncs/sign_script.py"
-
-config SUIT_ENVELOPE_ROOT_ARTIFACT_NAME
-    string "Name of the root SUIT artifact."
-    default ""
-    help
-        Name of the root SUIT artifact. If empty, 'root' name is used if this setting is empty.
-
-config SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY
-    string "Path to the folder with nordic top artifacts"
-    default ""
-    help
-      Path to the folder containing nordic-top.suit envelope.
-      nordic_top.suit won't be included in the root manifest if value is empty.
-
-endif # SUIT_ENVELOPE
+config SUIT_LOCAL_ENVELOPE_GENERATE
+  bool "Generate local envelope"
+  default y

--- a/ncs/app_envelope.yaml.jinja2
+++ b/ncs/app_envelope.yaml.jinja2
@@ -1,6 +1,6 @@
 {%- set mpi_application_vendor_name = application['config']['CONFIG_SUIT_MPI_APPlication_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
 {%- set mpi_application_class_name = application['config']['CONFIG_SUIT_MPI_APPlication_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_app') %}
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:
     SuitDigest:

--- a/ncs/app_envelope.yaml.jinja2
+++ b/ncs/app_envelope.yaml.jinja2
@@ -16,11 +16,11 @@ SUIT_Envelope_Tagged:
         - {{ application['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
       - - CAND_IMG
         - 0
-{%- if flash_companion_subimage is defined %}
+{%- if flash_companion is defined %}
       - - MEM
-        - {{ flash_companion_subimage['dt'].label2node['cpu'].unit_addr }}
-        - {{ get_absolute_address(flash_companion_subimage['dt'].chosen_nodes['zephyr,code-partition']) }}
-        - {{ flash_companion_subimage['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
+        - {{ flash_companion['dt'].label2node['cpu'].unit_addr }}
+        - {{ get_absolute_address(flash_companion['dt'].chosen_nodes['zephyr,code-partition']) }}
+        - {{ flash_companion['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
 {%- endif %}
       suit-shared-sequence:
       - suit-directive-set-component-index: 0
@@ -53,13 +53,13 @@ SUIT_Envelope_Tagged:
             suit-digest-algorithm-id: cose-alg-sha-256
             suit-digest-bytes:
               file: {{ application['binary'] }}
-{%- if flash_companion_subimage is defined %}
+{%- if flash_companion is defined %}
       - suit-directive-set-component-index: 2
       - suit-directive-override-parameters:
           suit-parameter-image-digest:
             suit-digest-algorithm-id: cose-alg-sha-256
             suit-digest-bytes:
-              file: {{ flash_companion_subimage['binary'] }}
+              file: {{ flash_companion['binary'] }}
 {%- endif %}
     suit-validate:
     - suit-directive-set-component-index: 0
@@ -73,14 +73,14 @@ SUIT_Envelope_Tagged:
     - suit-directive-invoke:
       - suit-send-record-failure
     suit-install:
-{%- if flash_companion_subimage is defined %}
+{%- if flash_companion is defined %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
-        suit-parameter-uri: '#{{ flash_companion_subimage['name'] }}'
+        suit-parameter-uri: '#{{ flash_companion['name'] }}'
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
-            file: {{ flash_companion_subimage['binary'] }}
+            file: {{ flash_companion['binary'] }}
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:
@@ -143,6 +143,6 @@ SUIT_Envelope_Tagged:
         suit-text-component-version: v1.0.0
   suit-integrated-payloads:
     '#{{ application['name'] }}': {{ application['binary'] }}
-{%- if flash_companion_subimage is defined %}
-    '#{{ flash_companion_subimage['name'] }}': {{ flash_companion_subimage['binary'] }}
+{%- if flash_companion is defined %}
+    '#{{ flash_companion['name'] }}': {{ flash_companion['binary'] }}
 {%- endif %}

--- a/ncs/build.py
+++ b/ncs/build.py
@@ -71,18 +71,22 @@ def read_configurations(configurations):
     """Read configuration stored in the pickled devicetree."""
     data = {}
     for config in configurations:
-        name, binary, edt = config.split(",")
-        kconfig = pathlib.Path(edt).parent / ".config"
-        with open(edt, "rb") as edt_handler:
-            edt = pickle.load(edt_handler)
-            # add prefix _ to the names starting with digits, for example:
-            #   802154_rpmsg_subimage will be available in the templates as _802154_rpmsg_subimage
-            data[f"_{name}" if re.match("^[0-9].*]", name) else name] = {
-                "name": name,
-                "config": BuildConfiguration(kconfig),
-                "dt": edt,
-                "binary": binary,
-            }
+        name, binary, edt, kconfig = config.split(",")
+        edt_data = None
+        if edt:
+            with open(edt, "rb") as edt_handler:
+                edt_data = pickle.load(edt_handler)
+        # add prefix _ to the names starting with digits, for example:
+        #   802154_rpmsg_subimage will be available in the templates as _802154_rpmsg_subimage
+        image_name = f"_{name}" if re.match("^[0-9].*]", name) else name
+        data[image_name] = {
+            "name": name,
+            "config": BuildConfiguration(kconfig),
+        }
+        if edt_data:
+            data[image_name]["dt"] = edt_data
+        if binary:
+            data[image_name]["binary"] = binary
     data["get_absolute_address"] = get_absolute_address
     return data
 

--- a/ncs/nordic_top_envelope.yaml.jinja2
+++ b/ncs/nordic_top_envelope.yaml.jinja2
@@ -1,4 +1,4 @@
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:
     SuitDigest:

--- a/ncs/rad_envelope.yaml.jinja2
+++ b/ncs/rad_envelope.yaml.jinja2
@@ -1,6 +1,6 @@
 {%- set mpi_radio_vendor_name = application['config']['CONFIG_SUIT_MPI_RADio_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
 {%- set mpi_radio_class_name = application['config']['CONFIG_SUIT_MPI_RADio_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:
     SuitDigest:

--- a/ncs/root_with_binary_nordic_top.yaml.jinja2
+++ b/ncs/root_with_binary_nordic_top.yaml.jinja2
@@ -6,8 +6,8 @@
 {%- set mpi_application_class_name = application['config']['CONFIG_SUIT_MPI_APPlication_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_app') %}
 {%- set mpi_radio_vendor_name = application['config']['CONFIG_SUIT_MPI_RADio_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
 {%- set mpi_radio_class_name = application['config']['CONFIG_SUIT_MPI_RADio_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
-{%- if 'CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY' in application['config'] and application['config']['CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] != '' %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- if 'SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY' in sysbuild['config'] and sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] != '' %}
   {%- set nordic_top = True %}
 {%- else %}
   {%- set nordic_top = False %}
@@ -162,7 +162,7 @@ SUIT_Envelope_Tagged:
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
-            envelope: {{ application['config']['CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] }}/nordic_top.suit
+            envelope: {{ sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] }}/nordic_top.suit
     - suit-directive-fetch:
       - suit-send-record-failure
     - suit-condition-image-match:
@@ -194,5 +194,5 @@ SUIT_Envelope_Tagged:
     '#{{ application['name'] }}': {{ artifacts_folder ~ application['name'] }}.suit
 {%- endif %}
 {%- if nordic_top %}
-    '#top': {{ application['config']['CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] }}/nordic_top.suit
+    '#top': {{ sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] }}/nordic_top.suit
 {%- endif %}

--- a/ncs/root_with_nordic_top_envelope.yaml.jinja2
+++ b/ncs/root_with_nordic_top_envelope.yaml.jinja2
@@ -6,7 +6,7 @@
 {%- set mpi_app_class_name = application['config']['CONFIG_SUIT_MPI_APP_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_app') %}
 {%- set mpi_rad_vendor_name = application['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
 {%- set mpi_rad_class_name = application['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 {%- if hci_rpmsg_subimage is defined %}
   {% set rad = hci_rpmsg_subimage %}
 {%- elif _802154_rpmsg_subimage is defined %}

--- a/ncs/secdom_update_envelope.yaml.jinja2
+++ b/ncs/secdom_update_envelope.yaml.jinja2
@@ -2,7 +2,7 @@
   {# secure domain build as main application #}
   {%- set secdom = app %}
 {%- endif %}
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:
     SuitDigest:

--- a/ncs/sysctrl_envelope.yaml.jinja2
+++ b/ncs/sysctrl_envelope.yaml.jinja2
@@ -3,7 +3,7 @@
   {# sysctrl domain build as main application #}
   {%- set sysctrl = app %}
 {%- endif %}
-{%- set sequence_number = application['config']['CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
+{%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:
     SuitDigest:


### PR DESCRIPTION
* Certain Kconfigs affecting more than one image were moved to sysbuild in sdk-nrf.
* The SUIT build system integration in sdk-nrf now defines a target named `sysbuild` that contains sysbuild Kconfig options. There is no binary or devicetree associated with it.
* All images built within the given sysbuild are now accessible during the template rendering. The image name is the name of the application supplied in `ExternalZephyrProject_Add`, therefore `flash_companion_subimage` was renamed to `flash_companion`.