### PR TITLE
feat: enable local envelope generation only for rad and app

### DIFF
--- a/ncs/Kconfig
+++ b/ncs/Kconfig
@@ -28,4 +28,4 @@ config SUIT_ENVELOPE_OUTPUT_MPI_MERGE
 
 config SUIT_LOCAL_ENVELOPE_GENERATE
   bool "Generate local envelope"
-  default y
+  default y if SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD

--- a/ncs/rad_envelope.yaml.jinja2
+++ b/ncs/rad_envelope.yaml.jinja2
@@ -1,5 +1,10 @@
-{%- set mpi_radio_vendor_name = application['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
-{%- set mpi_radio_class_name = application['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
+{%- if application is not defined %}
+  {%- set main_config = radio %}
+{%- else %}
+  {%- set main_config = application %}
+{%- endif %}
+{%- set mpi_radio_vendor_name = main_config['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
+{%- set mpi_radio_class_name = main_config['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
 {%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 SUIT_Envelope_Tagged:
   suit-authentication-wrapper:

--- a/ncs/rad_envelope.yaml.jinja2
+++ b/ncs/rad_envelope.yaml.jinja2
@@ -1,7 +1,7 @@
-{%- if application is not defined %}
-  {%- set main_config = radio %}
-{%- else %}
+{%- if application is defined %}
   {%- set main_config = application %}
+{%- else %}
+  {%- set main_config = radio %}
 {%- endif %}
 {%- set mpi_radio_vendor_name = main_config['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
 {%- set mpi_radio_class_name = main_config['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}

--- a/ncs/root_with_binary_nordic_top.yaml.jinja2
+++ b/ncs/root_with_binary_nordic_top.yaml.jinja2
@@ -1,11 +1,16 @@
 {%- set component_index = 0 %}
 {%- set component_list = [] %}
-{%- set mpi_root_vendor_name = application['config']['CONFIG_SUIT_MPI_ROOT_VENDOR_NAME']|default('nordicsemi.com') %}
-{%- set mpi_root_class_name = application['config']['CONFIG_SUIT_MPI_ROOT_CLASS_NAME']|default('nRF54H20_sample_root') %}
-{%- set mpi_application_vendor_name = application['config']['CONFIG_SUIT_MPI_APP_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
-{%- set mpi_application_class_name = application['config']['CONFIG_SUIT_MPI_APP_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_app') %}
-{%- set mpi_radio_vendor_name = application['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
-{%- set mpi_radio_class_name = application['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
+{%- if application is not defined %}
+  {%- set main_config = radio %}
+{%- else %}
+  {%- set main_config = application %}
+{%- endif %}
+{%- set mpi_root_vendor_name = main_config['config']['CONFIG_SUIT_MPI_ROOT_VENDOR_NAME']|default('nordicsemi.com') %}
+{%- set mpi_root_class_name = main_config['config']['CONFIG_SUIT_MPI_ROOT_CLASS_NAME']|default('nRF54H20_sample_root') %}
+{%- set mpi_application_vendor_name = main_config['config']['CONFIG_SUIT_MPI_APP_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
+{%- set mpi_application_class_name = main_config['config']['CONFIG_SUIT_MPI_APP_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_app') %}
+{%- set mpi_radio_vendor_name = main_config['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_VENDOR_NAME']|default('nordicsemi.com') %}
+{%- set mpi_radio_class_name = main_config['config']['CONFIG_SUIT_MPI_RAD_LOCAL_1_CLASS_NAME']|default('nRF54H20_sample_rad') %}
 {%- set sequence_number = sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM'] %}
 {%- if 'SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY' in sysbuild['config'] and sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] != '' %}
   {%- set nordic_top = True %}


### PR DESCRIPTION
Enable local envelope generation only for application and radio cores.

Ref: NCSDK-27372

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>