### PR TITLE
ncs: envelopes: Verify child manifests before install

### DIFF
--- a/ncs/nordic_top_envelope.yaml.jinja2
+++ b/ncs/nordic_top_envelope.yaml.jinja2
@@ -88,7 +88,39 @@ SUIT_Envelope_Tagged:
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
+
     suit-install:
+    - suit-directive-set-component-index: 0
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ secdom['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ sysctrl['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+
+    suit-candidate-verification:
     - suit-directive-set-component-index: 0
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ secdom['name'] }}'
@@ -136,6 +168,7 @@ SUIT_Envelope_Tagged:
       - suit-send-record-failure
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
+
     suit-manifest-component-id:
     - INSTLD_MFST
     - RFC4122_UUID:

--- a/ncs/root_with_binary_nordic_top.yaml.jinja2
+++ b/ncs/root_with_binary_nordic_top.yaml.jinja2
@@ -114,6 +114,57 @@ SUIT_Envelope_Tagged:
 {%- if radio is defined %}
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ radio['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+{%- endif %}
+{%- if application is defined %}
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ application['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+{%- endif %}
+{%- if nordic_top %}
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#top'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+{%- endif %}
+
+    suit-candidate-verification:
+    - suit-directive-set-component-index: 0
+{%- if radio is defined %}
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ radio['name'] }}'
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -186,6 +237,7 @@ SUIT_Envelope_Tagged:
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
 {%- endif %}
+
     suit-manifest-component-id:
     - INSTLD_MFST
     - RFC4122_UUID:

--- a/ncs/root_with_nordic_top_envelope.yaml.jinja2
+++ b/ncs/root_with_nordic_top_envelope.yaml.jinja2
@@ -111,6 +111,57 @@ SUIT_Envelope_Tagged:
 {%- if radio is defined %}
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ radio['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+{%- endif %}
+{%- if application is defined %}
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ application['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+{%- endif %}
+{%- if top is defined %}
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ top['name'] }}'
+    - suit-directive-fetch:
+      - suit-send-record-failure
+    - suit-condition-dependency-integrity:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+    - suit-directive-process-dependency:
+      - suit-send-record-success
+      - suit-send-record-failure
+      - suit-send-sysinfo-success
+      - suit-send-sysinfo-failure
+{%- endif %}
+
+    suit-candidate-verification:
+    - suit-directive-set-component-index: 0
+{%- if radio is defined %}
+    - suit-directive-override-parameters:
+        suit-parameter-uri: '#{{ radio['name'] }}'
         suit-parameter-image-digest:
           suit-digest-algorithm-id: cose-alg-sha-256
           suit-digest-bytes:
@@ -183,6 +234,7 @@ SUIT_Envelope_Tagged:
       - suit-send-sysinfo-success
       - suit-send-sysinfo-failure
 {%- endif %}
+
     suit-manifest-component-id:
     - INSTLD_MFST
     - RFC4122_UUID:


### PR DESCRIPTION
It is worth checking if all dependency manifests were correctly downloaded prior suit-install sequence execution.

Ref: NCSDK-NONE