### PR TITLE
suit: Remove the possibility to merge MPIs

### DIFF
--- a/ncs/Kconfig
+++ b/ncs/Kconfig
@@ -22,10 +22,6 @@ config SUIT_ENVELOPE_OUTPUT_ARTIFACT
   string "Name of the output merged artifact"
   default "merged.hex"
 
-config SUIT_ENVELOPE_OUTPUT_MPI_MERGE
-  bool "Merge MPI files into final SUIT_ENVELOPE_OUTPUT_ARTIFACT"
-  default y
-
 config SUIT_LOCAL_ENVELOPE_GENERATE
   bool "Generate local envelope"
   default y if SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD


### PR DESCRIPTION
Remove the possibility to merge MPIs with the final HEX. Use the dedicated logic inside the nrf_common.py to flash those regions independently.

Ref: NCSDK-27790