### PR TITLE
fix: calculate envelope digest by specified algorithm

### DIFF
--- a/suit_generator/suit/authentication.py
+++ b/suit_generator/suit/authentication.py
@@ -147,7 +147,7 @@ class SuitDigestExt(PrettyPrintHelperMixin):
                         sub_envelope = SuitEnvelopeTagged.from_cbor(fh.read())
                 sub_envelope.update_severable_digests()
                 sub_envelope.update_digest()
-                obj[suit_digest_bytes.name] = sub_envelope.get_digest().SuitDigestRaw[1].SuitDigestBytes.hex()
+                obj[suit_digest_bytes.name] = sub_envelope.get_manifest_digest(obj[suit_digest_algorithm_id.name]).hex()
             elif "raw" in digest_dict.keys():
                 obj[suit_digest_bytes.name] = digest_dict["raw"]
             else:

--- a/suit_generator/suit/envelope.py
+++ b/suit_generator/suit/envelope.py
@@ -78,16 +78,23 @@ class SuitBasicEnvelopeOperationsMixin:
         alg = (
             self.value.value.value[suit_authentication_wrapper].SuitAuthentication[0].SuitDigest.SuitDigestRaw[0].value
         )
-        manifest = self.value.value.value[suit_manifest].to_cbor()
-        hash_func = SuitHash(alg)
-        new_digest = binascii.a2b_hex(hash_func.hash(manifest))
         self.value.value.value[suit_authentication_wrapper].SuitAuthentication[0].SuitDigest.SuitDigestRaw[
             1
-        ].SuitDigestBytes = new_digest
+        ].SuitDigestBytes = self.get_manifest_digest(alg)
 
     def get_digest(self):
         """Return digest from parsed envelope."""
         return self.value.value.value[suit_authentication_wrapper].SuitAuthentication[0].SuitDigest
+
+    def get_manifest(self):
+        """Return manifest from parsed envelope."""
+        return self.value.value.value[suit_manifest]
+
+    def get_manifest_digest(self, alg):
+        """Return digest from parsed envelope."""
+        manifest = self.get_manifest().to_cbor()
+        hash_func = SuitHash(alg)
+        return binascii.a2b_hex(hash_func.hash(manifest))
 
     def update_severable_digests(self):
         """Update digest in the envelope for severed elements."""


### PR DESCRIPTION
Previously, the envelope digest used in the parent envelope was calculated using the same algorithm as the digest for the child envelope authentication block.

Now the digest algorithms used in the parent and child manifests are separate.