### PR TITLE
templates: add streaming operation retry and remove flash companion processing from default template

### DIFF
--- a/ncs/app_envelope.yaml.jinja2
+++ b/ncs/app_envelope.yaml.jinja2
@@ -49,11 +49,21 @@ SUIT_Envelope_Tagged:
               file: {{ application['binary'] }}
     suit-validate:
     - suit-directive-set-component-index: 0
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # In the case of streaming operations it is worth to retry them at least once.
+    # This increases the robustness against bit flips on the transport,
+    # for example when storing the data on an external memory device.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     suit-invoke:
     - suit-directive-set-component-index: 0
     - suit-directive-invoke:
@@ -68,21 +78,41 @@ SUIT_Envelope_Tagged:
             file: {{ application['binary'] }}
     - suit-directive-fetch:
       - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     - suit-directive-set-component-index: 0
     - suit-directive-override-parameters:
         suit-parameter-source-component: 1
-    - suit-directive-copy:
-      - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # When copying the data it is worth to retry the sequence of
+    # suit-directive-copy and suit-condition-image-match at least once.
+    # If a bit flip occurs, it might be due to a transport issue, not
+    # a corrupted candidate image. In this case the bit flip is recoverable
+    # and it is worth retrying the operation.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-directive-copy:
+          - suit-send-record-failure
+        - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-directive-copy:
+          - suit-send-record-failure
+        - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     suit-text:
       suit-digest-algorithm-id: cose-alg-sha-256
     suit-manifest-component-id:

--- a/ncs/app_envelope.yaml.jinja2
+++ b/ncs/app_envelope.yaml.jinja2
@@ -16,12 +16,6 @@ SUIT_Envelope_Tagged:
         - {{ application['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
       - - CAND_IMG
         - 0
-{%- if flash_companion is defined %}
-      - - MEM
-        - {{ flash_companion['dt'].label2node['cpu'].unit_addr }}
-        - {{ get_absolute_address(flash_companion['dt'].chosen_nodes['zephyr,code-partition']) }}
-        - {{ flash_companion['dt'].chosen_nodes['zephyr,code-partition'].regs[0].size }}
-{%- endif %}
       suit-shared-sequence:
       - suit-directive-set-component-index: 0
       - suit-directive-override-parameters:
@@ -53,14 +47,6 @@ SUIT_Envelope_Tagged:
             suit-digest-algorithm-id: cose-alg-sha-256
             suit-digest-bytes:
               file: {{ application['binary'] }}
-{%- if flash_companion is defined %}
-      - suit-directive-set-component-index: 2
-      - suit-directive-override-parameters:
-          suit-parameter-image-digest:
-            suit-digest-algorithm-id: cose-alg-sha-256
-            suit-digest-bytes:
-              file: {{ flash_companion['binary'] }}
-{%- endif %}
     suit-validate:
     - suit-directive-set-component-index: 0
     - suit-condition-image-match:
@@ -73,34 +59,6 @@ SUIT_Envelope_Tagged:
     - suit-directive-invoke:
       - suit-send-record-failure
     suit-install:
-{%- if flash_companion is defined %}
-    - suit-directive-set-component-index: 1
-    - suit-directive-override-parameters:
-        suit-parameter-uri: '#{{ flash_companion['name'] }}'
-        suit-parameter-image-digest:
-          suit-digest-algorithm-id: cose-alg-sha-256
-          suit-digest-bytes:
-            file: {{ flash_companion['binary'] }}
-    - suit-directive-fetch:
-      - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
-    - suit-directive-set-component-index: 2
-    - suit-directive-override-parameters:
-        suit-parameter-source-component: 1
-    - suit-directive-copy:
-      - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
-    - suit-directive-invoke:
-      - suit-send-record-failure
-{%- endif %}
     - suit-directive-set-component-index: 1
     - suit-directive-override-parameters:
         suit-parameter-uri: '#{{ application['name'] }}'
@@ -143,6 +101,3 @@ SUIT_Envelope_Tagged:
         suit-text-component-version: v1.0.0
   suit-integrated-payloads:
     '#{{ application['name'] }}': {{ application['binary'] }}
-{%- if flash_companion is defined %}
-    '#{{ flash_companion['name'] }}': {{ flash_companion['binary'] }}
-{%- endif %}

--- a/ncs/rad_envelope.yaml.jinja2
+++ b/ncs/rad_envelope.yaml.jinja2
@@ -54,11 +54,21 @@ SUIT_Envelope_Tagged:
               file: {{ radio['binary'] }}
     suit-validate:
     - suit-directive-set-component-index: 0
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # In the case of streaming operations it is worth to retry them at least once.
+    # This increases the robustness against bit flips on the transport,
+    # for example when storing the data on an external memory device.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     suit-invoke:
     - suit-directive-set-component-index: 0
     - suit-directive-invoke:
@@ -69,21 +79,41 @@ SUIT_Envelope_Tagged:
         suit-parameter-uri: '#{{ radio['name'] }}'
     - suit-directive-fetch:
       - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     - suit-directive-set-component-index: 0
     - suit-directive-override-parameters:
         suit-parameter-source-component: 1
-    - suit-directive-copy:
-      - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # When copying the data it is worth to retry the sequence of
+    # suit-directive-copy and suit-condition-image-match at least once.
+    # If a bit flip occurs, it might be due to a transport issue, not
+    # a corrupted candidate image. In this case the bit flip is recoverable
+    # and it is worth retrying the operation.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-directive-copy:
+          - suit-send-record-failure
+        - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-directive-copy:
+          - suit-send-record-failure
+        - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     suit-text:
       suit-digest-algorithm-id: cose-alg-sha-256
     suit-manifest-component-id:

--- a/ncs/root_with_binary_nordic_top.yaml.jinja2
+++ b/ncs/root_with_binary_nordic_top.yaml.jinja2
@@ -171,11 +171,21 @@ SUIT_Envelope_Tagged:
             envelope: {{ artifacts_folder ~ radio['name'] }}.suit
     - suit-directive-fetch:
       - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # In the case of streaming operations it is worth to retry them at least once.
+    # This increases the robustness against bit flips on the transport,
+    # for example when storing the data on an external memory device.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     - suit-condition-dependency-integrity:
       - suit-send-record-success
       - suit-send-record-failure
@@ -196,11 +206,21 @@ SUIT_Envelope_Tagged:
             envelope: {{ artifacts_folder ~ application['name'] }}.suit
     - suit-directive-fetch:
       - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # In the case of streaming operations it is worth to retry them at least once.
+    # This increases the robustness against bit flips on the transport,
+    # for example when storing the data on an external memory device.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     - suit-condition-dependency-integrity:
       - suit-send-record-success
       - suit-send-record-failure
@@ -221,11 +241,21 @@ SUIT_Envelope_Tagged:
             envelope: {{ sysbuild['config']['SB_CONFIG_SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY'] }}/nordic_top.suit
     - suit-directive-fetch:
       - suit-send-record-failure
-    - suit-condition-image-match:
-      - suit-send-record-success
-      - suit-send-record-failure
-      - suit-send-sysinfo-success
-      - suit-send-sysinfo-failure
+    # In the case of streaming operations it is worth to retry them at least once.
+    # This increases the robustness against bit flips on the transport,
+    # for example when storing the data on an external memory device.
+    # The suit-directive-try-each will complete on the first successful subsequence.
+    - suit-directive-try-each:
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
+      - - suit-condition-image-match:
+          - suit-send-record-success
+          - suit-send-record-failure
+          - suit-send-sysinfo-success
+          - suit-send-sysinfo-failure
     - suit-condition-dependency-integrity:
       - suit-send-record-success
       - suit-send-record-failure


### PR DESCRIPTION
* templates: remove flash companion from default template

    The flash companion is not used in default configurations.

* templates: add retries for streaming operations

    Streaming operations, such as calculating the digest or 
    suit-directive-copy are now executed at least twice.

    This increases the robustness of the update process and may prevent the
    device from entering the recovery state when a bit flip occurs during
    the streaming operation, but the update candidate is correct and
    uncorrupted. In such cases, the bit flip is recoverable.
    The device will repeat the streaming operation with the hope that the
    bit flip does not occur again.
    One source of recoverable bit flips may be interference on the SPI bus when
    streaming from external memory, or a bit flip when writing a candidate to NVM.