### PR TITLE
authentication: Fix incorrect signed data in sign_script.py

### DIFF
--- a/ncs/sign_script.py
+++ b/ncs/sign_script.py
@@ -89,7 +89,8 @@ class Signer:
     def create_cose_structure(self, protected: dict):
         """Create COSE Sig_structure."""
         data = ["Signature1", cbor2.dumps(protected), b"", cbor2.dumps(self.get_digest())]
-        return cbor2.dumps(data)
+        return cbor2.dumps(cbor2.dumps(data)) # First encode as array, then as bstr
+
 
     def get_digest(self):
         """Return digest object."""


### PR DESCRIPTION
The signature was calculated based on the Sig_structure1 structure, while according to the specification it should be checked based on the structure encrypted in a bstr.