### PR TITLE
Raise exception in case of vid/cid duplicates

### DIFF
--- a/suit_generator/cmd_image.py
+++ b/suit_generator/cmd_image.py
@@ -190,6 +190,15 @@ class EnvelopeStorage:
         for key, value in config.items():
             if re_value := re.match(r"^CONFIG_SUIT_MPI_(?P<manifest>[A-Z1-9_]+)_VENDOR_NAME$", key):
                 manifest = re_value.group("manifest")
+                # ensure that the same combination of vid/cid has not been set for different role
+                for item in kconfig_assignments:
+                    if (
+                        item["vendor_name"] == config[f"CONFIG_SUIT_MPI_{manifest}_VENDOR_NAME"]
+                        and item["class_name"] == config[f"CONFIG_SUIT_MPI_{manifest}_CLASS_NAME"]
+                    ):
+                        raise GeneratorError(
+                            "Duplicate vid/cid combination for different roles detected in the KConfig file."
+                        )
                 data = {
                     "vendor_name": config[f"CONFIG_SUIT_MPI_{manifest}_VENDOR_NAME"],
                     "class_name": config[f"CONFIG_SUIT_MPI_{manifest}_CLASS_NAME"],

--- a/tests/test_cmd_image.py
+++ b/tests/test_cmd_image.py
@@ -547,10 +547,9 @@ def test_nrf54_storage_custom_config_with_defaults_overwrite(setup_and_teardown)
 
 
 def test_nrf54_storage_custom_config_with_role_change_duplicates(setup_and_teardown):
-    storage = EnvelopeStorageNrf54h20(base_address=0xFF, load_defaults=True, kconfig=".config_duplicates")
-    # 8 default assignments + 3 custom assignments: root uses default value, APP and RAD uses the same role.
-    # APP entry will be overwritten by RAD to there will be no APP role in the dictionary, only RAD but duplicated.
-    assert len(storage._assignments) == 8
+    with pytest.raises(GeneratorError):
+        # GeneratorError shall be raised due to duplicated assignments
+        EnvelopeStorageNrf54h20(base_address=0xFF, load_defaults=True, kconfig=".config_duplicates")
 
 
 def test_nrf54_storage_custom_config_with_role_change_no_duplicates(setup_and_teardown):


### PR DESCRIPTION
feat: custom vid/cid validation

Add validation for duplicate vid/cid combinations in KConfig file and update corresponding test

Ref: NCSDK-28254

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no