### PR TITLE
Added SUIT_RECOVERY Kconfig option

### DIFF
--- a/ncs/Kconfig
+++ b/ncs/Kconfig
@@ -10,25 +10,36 @@ config SSF_SUIT_SERVICE_ENABLED
 
 config SUIT_ENVELOPE_TEMPLATE_FILENAME
 	string "Path to the envelope template"
-	default "app_envelope.yaml.jinja2" if SOC_NRF54H20_CPUAPP
-	default "rad_envelope.yaml.jinja2" if SOC_NRF54H20_CPURAD
+	default "app_envelope.yaml.jinja2" if SOC_NRF54H20_CPUAPP && !SUIT_RECOVERY
+	default "rad_envelope.yaml.jinja2" if SOC_NRF54H20_CPURAD && !SUIT_RECOVERY
+	default "rad_recovery_envelope.yaml.jinja2" if SOC_NRF54H20_CPURAD && SUIT_RECOVERY
 
 config SUIT_ENVELOPE_TARGET
 	string "Target name inside the envelope templates"
-	default "application" if SOC_NRF54H20_CPUAPP
-	default "radio" if SOC_NRF54H20_CPURAD
+	default "application" if SOC_NRF54H20_CPUAPP && !SUIT_RECOVERY
+	default "radio" if SOC_NRF54H20_CPURAD && !SUIT_RECOVERY
+	default "app_recovery" if SOC_NRF54H20_CPUAPP && SUIT_RECOVERY
+	default "rad_recovery" if SOC_NRF54H20_CPURAD && SUIT_RECOVERY
 
 config SUIT_ENVELOPE_OUTPUT_ARTIFACT
 	string "Name of the output merged artifact"
 	default "merged.hex"
 
+config SUIT_RECOVERY
+	bool "The given image is part of a SUIT recovery application"
+	depends on !NRF_REGTOOL_GENERATE_UICR
+
 config SUIT_ENVELOPE_OUTPUT_MPI_MERGE
 	bool "Merge MPI files into final SUIT_ENVELOPE_OUTPUT_ARTIFACT"
-	default y
+	default y if !SUIT_RECOVERY
 
 config SUIT_LOCAL_ENVELOPE_GENERATE
 	bool "Generate local envelope"
-	default y if SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
+	# In case of the recovery application, the "application" envelope, containing
+	# the application firmware image, is actually the root envelope from
+	# the build system's point of view.
+	# That is why no local envelope is generated for the application.
+	default y if (SOC_NRF54H20_CPUAPP && !SUIT_RECOVERY) || SOC_NRF54H20_CPURAD
 
 config SUIT_DFU_CACHE_EXTRACT_IMAGE
 	bool "Extract firmware image to DFU cache"
@@ -49,7 +60,9 @@ config SUIT_DFU_CACHE_EXTRACT_IMAGE_PARTITION
 
 config SUIT_DFU_CACHE_EXTRACT_IMAGE_URI
 	string "The URI used as key for the image in the DFU cache"
-	default "cache://application.bin" if SOC_NRF54H20_CPUAPP
-	default "cache://radio.bin" if SOC_NRF54H20_CPURAD
+	default "cache://application.bin" if SOC_NRF54H20_CPUAPP && !SUIT_RECOVERY
+	default "cache://radio.bin" if SOC_NRF54H20_CPURAD && !SUIT_RECOVERY
+	default "cache://app_recovery.bin" if SOC_NRF54H20_CPUAPP && SUIT_RECOVERY
+	default "cache://rad_recovery.bin" if SOC_NRF54H20_CPURAD && SUIT_RECOVERY
 
 endif # SUIT_DFU_CACHE_EXTRACT_IMAGE


### PR DESCRIPTION
Needed mostly for creation of a separate .zip file, but also allows to simplify the configuration
of a recovery application.

Ref: NCSDK-29206