### PR TITLE
feat: add GH action to check contributors write access to the repo

### DIFF
--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -1,0 +1,15 @@
+name: "Check User Write Access"
+
+on: [push, pull_request]
+
+jobs:
+  check-write-access:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Check if user has write access"
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Mark "PR" in red for users without write access.

Ref: NCSDK-31175

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>