### PR TITLE
feat: Add target parameter to specify primary image

### DIFF
--- a/ncs/build.py
+++ b/ncs/build.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
         help="Configuration of sample name:location of binaries:location of edt",
     )
     parent_parser.add_argument("--zephyr-base", required=True, help="Location of zephyr directory.")
-    parent_parser.add_argument("--target", required=False, default=None, help="Target name.")    
+    parent_parser.add_argument("--target", required=False, default=None, help="Target name.")
 
     parser = ArgumentParser(add_help=False)
 

--- a/ncs/build.py
+++ b/ncs/build.py
@@ -51,7 +51,8 @@ def read_configurations(configurations, target):
         if image_name in data:
             existing_binary = data[image_name]["binary"]
             raise ValueError(
-                f"Two images have the same CONFIG_SUIT_ENVELOPE_TARGET value for image {image_name}: {binary} and {existing_binary}"
+                f"Two images have the same CONFIG_SUIT_ENVELOPE_TARGET value for "
+                f"image {image_name}: {binary} and {existing_binary}"
             )
 
         data[image_name] = {

--- a/suit_generator/cmd_image.py
+++ b/suit_generator/cmd_image.py
@@ -300,7 +300,7 @@ class EnvelopeStorage:
                     raise GeneratorError(
                         f"Unable to fit envelope with role {role} inside the envelope slot (max: {max_size} bytes)"
                     )
-                envelope_bytes = self._envelopes[role].ljust(max_size, b"\xFF")
+                envelope_bytes = self._envelopes[role].ljust(max_size, b"\xff")
                 envelope_count += 1
             else:
                 continue

--- a/suit_generator/cmd_mpi.py
+++ b/suit_generator/cmd_mpi.py
@@ -143,13 +143,13 @@ class MpiGenerator:
             + downgrade_prevention_enabled_bytes
             + independent_updates_bytes
             + signature_verification_bytes
-            + b"\xFF" * 12  # Reserved for future use
+            + b"\xff" * 12  # Reserved for future use
             + vid.bytes
             + cid.bytes
         )
 
         mpi_hex = IntelHex()
-        mpi_hex.frombytes(mpi.ljust(size, b"\xFF"), address)
+        mpi_hex.frombytes(mpi.ljust(size, b"\xff"), address)
         mpi_hex.write_hex_file(output_file)
 
     @staticmethod

--- a/tests/test_cmd_image.py
+++ b/tests/test_cmd_image.py
@@ -21,8 +21,8 @@ TEMP_DIRECTORY = pathlib.Path("test_test_data")
 
 MAX_CACHE_COUNT = 16
 
-addresses = {0x00000000: b"\x00\x00\x00\x00", 0xDEADBEEF: b"\xEF\xBE\xAD\xDE", 0xFFFFFFFF: b"\xFF\xFF\xFF\xFF"}
-sizes = {0x00000000: b"\x00\x00\x00\x00", 0x01020304: b"\x04\x03\x02\x01", 0xFFFFFFFF: b"\xFF\xFF\xFF\xFF"}
+addresses = {0x00000000: b"\x00\x00\x00\x00", 0xDEADBEEF: b"\xef\xbe\xad\xde", 0xFFFFFFFF: b"\xff\xff\xff\xff"}
+sizes = {0x00000000: b"\x00\x00\x00\x00", 0x01020304: b"\x04\x03\x02\x01", 0xFFFFFFFF: b"\xff\xff\xff\xff"}
 
 signed_envelope_without_class_id_input = (
     b"\xd8k\xa4\x02X'\x81X$\x82/X 7d\x90\xc1\xa5\x84\xc1\xed\xeeO\x0f\xd6\xad\xc5t\xb0\x1dr\xb5r"
@@ -346,7 +346,7 @@ def test_update_candidate_info_verify_class_id_offset():
 @pytest.mark.parametrize("address", addresses)
 @pytest.mark.parametrize("size", sizes)
 def test_update_candidate_info_for_update(address, size, nb_of_caches):
-    magic_bytes = b"\xAA\x55\xAA\x55"
+    magic_bytes = b"\xaa\x55\xaa\x55"
     nregions_bytes = b"\x01\x00\x00\x00"
     address_bytes = addresses[address]
     size_bytes = sizes[size]

--- a/tests/test_ncs_sign_script.py
+++ b/tests/test_ncs_sign_script.py
@@ -165,7 +165,7 @@ def test_ncs_cose(setup_and_teardown):
 def test_ncs_auth_block(setup_and_teardown):
     """Test if is possible to create authentication block using ncs sign_script.py."""
     signer = suit_signer_factory()
-    auth_block = signer.create_authentication_block({}, {}, b"\xDE\xAD\xBE\xEF")
+    auth_block = signer.create_authentication_block({}, {}, b"\xde\xad\xbe\xef")
     assert isinstance(auth_block, cbor2.CBORTag)
 
 


### PR DESCRIPTION
Add --target parameter that allows specifying the
primary image in SUIT configuration. Also improve error message for duplicate image names to be more descriptive.

Ref: NCSDK-30812

Signed-off-by: Robert Stypa <robert.stypa@nordicsemi.no>